### PR TITLE
Fix load order with 5Dim's mods

### DIFF
--- a/info.json
+++ b/info.json
@@ -13,6 +13,7 @@
     "(?) no-pipe-touching",
     "(?) janus",
     "(?) combat-mechanics-overhaul",
-    "(?) space-exploration"
+    "(?) space-exploration",
+    "(?) 5dim_compatibility"
   ]
 }


### PR DESCRIPTION
For some reason, https://mods.factorio.com/mod/5dim_compatibility does some stuff to pipes at the end of the prototype stage? It breaks the mod entirely, and makes underground pipes collide with everything, which clearly is not the intended way for them to work. Just adding this optional dependency changes the load order and fixed it for me.

I'm not sure 100% if this happens all the time with 5Dim, or if it requires other mods too to cause it. I had it happen when playing https://mods.factorio.com/mod/all-the-overhaul-modpack + this mod.